### PR TITLE
Dodano: Transport > Lądowy > Lokalizacja pojazdów > Czynaczas.pl

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1793,6 +1793,11 @@
                   "name": "PKP - Portal Pasażera",
                   "type": "url",
                   "url": "https://portalpasazera.pl/MapaOL"
+                },
+                {
+                  "name": "Czynaczas.pl",
+                  "type": "url",
+                  "url": "https://czynaczas.pl"
                 }
               ],
               "name": "Lokalizacja pojazdów",


### PR DESCRIPTION
Dodano url do [https://czynaczas.pl](https://czynaczas.pl)